### PR TITLE
Silence a Nix warning

### DIFF
--- a/nix/dependencies.nix
+++ b/nix/dependencies.nix
@@ -1,6 +1,6 @@
 final: prev: {
   emacsPackagesFor = emacs:
-    (prev.emacsPackagesFor emacs).overrideScope' (efinal: eprev: {
+    (prev.emacsPackagesFor emacs).overrideScope (efinal: eprev: {
       # The `eldev` package doesn’t expose the executable.
       eldev = eprev.eldev.overrideAttrs (old: {
         postInstall = ''


### PR DESCRIPTION
`overrideScope'` has dropped its prime, resulting in a warning here and on
downstream consumers. It is extremely hard to track this kind of warning down,
so now that we have, stop annoying users with it.